### PR TITLE
Changed identification of Entity vs. Complex types to only care about the key

### DIFF
--- a/MR3/Extensions/OData/src/Castle.MonoRail.Extension.ODataFs/ResourceMetadataBuilder.fs
+++ b/MR3/Extensions/OData/src/Castle.MonoRail.Extension.ODataFs/ResourceMetadataBuilder.fs
@@ -76,7 +76,7 @@ namespace Castle.MonoRail.Extension.OData
         let private resolve_resourceTypeKind_based_on_properties (entType:Type) = 
             let hasKeyOrNonPrimitives = 
                 entType.GetProperties(PropertiesBindingFlags)
-                |> Seq.exists (fun p -> p.IsDefined(typeof<KeyAttribute>, true) || not <| is_primitive p.PropertyType)
+                |> Seq.exists (fun p -> p.IsDefined(typeof<KeyAttribute>, true))
             if hasKeyOrNonPrimitives 
             then ResourceTypeKind.EntityType
             else ResourceTypeKind.ComplexType


### PR DESCRIPTION
## @hammett

OData V3 Specs:

Entities are instances of entity types (e.g. Customer, Employee, etc.). Entity types are nominal structured types with a key. Entities consist of named properties and MAY include relationships with other entities. Entity types support single inheritance from other entity types. Entities are the core identity types in a data model.

Complex types are keyless nominal structural types consisting of a set of properties. These are value types that lack identity. Complex types are commonly used as property values in an entity or as parameters to operations.
