### PR TITLE
WebSiteForIntegration post build problem

### DIFF
--- a/MR3/tests/WebSiteForIntegration/WebSiteForIntegration.csproj
+++ b/MR3/tests/WebSiteForIntegration/WebSiteForIntegration.csproj
@@ -115,7 +115,7 @@
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)build\mrtypegen.exe -b:$(TargetPath) -t:$(ProjectDir)Generated</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)build\mrtypegen.exe" -b:"$(TargetPath)" -t:"$(ProjectDir)Generated"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
mrtypegen.exe would fail when there were spaces in the paths
